### PR TITLE
Added matching for label text

### DIFF
--- a/formfiller/js-chrome/content.js
+++ b/formfiller/js-chrome/content.js
@@ -290,7 +290,11 @@ var FormFiller = function ($, options) {
         },
 
         getSanitizedElementName = function (element) {
-            return sanitizeName(element.name) + ' ' + sanitizeName(element.id) + ' ' + sanitizeName(element.className);
+            var sanitizedElementName = sanitizeName(element.name) + ' ' + sanitizeName(element.id) + ' ' + sanitizeName(element.className);
+            var label = $("label[for='"+ element.id +"']");
+        	if (label.length == 1)
+        		sanitizedElementName += ' ' + sanitizeName(label.html());
+        	return sanitizedElementName;
         },
 
         sanitizeName = function (name) {

--- a/formfiller/partials/custom-fields.html
+++ b/formfiller/partials/custom-fields.html
@@ -1,7 +1,7 @@
 <h2>Custom Fields</h2>
 <p>Form Filler uses the ID, NAME and CLASS values of an input field to determine its data type. You can adjust the
     search phrases in the text boxes below to tweak how Form Filler determines the correct data types.</p>
-<p>Basically, any partial match in the attributes underlined:<br><code>&lt;input type="<i>anything</i>"
+<p>Basically, any partial match in the attributes underlined:<br><code>&lt;label for="match" &gt;<b><u>match</u></b>&lt;/label&gt;</code><br><code>&lt;input type="<i>anything</i>"
     id="<b><u>match</u></b>" name="<b><u>match</u></b>" class="<b><u>match</u></b>" /&gt;
 </code></p>
 <p>Please note that attributes take precedence over any configuration and may override it in some cases. Also, fields


### PR DESCRIPTION
Field matching now works with label text.
The text of the label having a "for" attribute matching field "id"
attribute is taken into consideration.
