### PR TITLE
Allow "-" and "_" as Match field.

### DIFF
--- a/formfiller/js-chrome/content.js
+++ b/formfiller/js-chrome/content.js
@@ -317,7 +317,7 @@ var FormFiller = function ($, options) {
         },
 
         sanitizeName = function (name) {
-            return name.replace(/[^a-zA-Z0-9]+/g, '').toLowerCase();
+            return name.replace(/[^a-zA-Z0-9\-_]+/g, '').toLowerCase();
         },
 
         getFieldFromElement = function (elementName, matchType) {

--- a/formfiller/partials/custom-fields.html
+++ b/formfiller/partials/custom-fields.html
@@ -12,7 +12,7 @@
 <ul>
     <li>Attributes take precedence over any configuration and may override it in some cases,</li>
     <li>The fields are matched based on the order of the custom fields, and</li>
-    <li>All punctuations are removed before being matched (e.g. user_name will become username).</li>
+    <li>All punctuations other than "-" and "_" are removed before being matched (e.g. user[name] will become username).</li>
 </ul>
 <hr/>
 <div class="btn-toolbar">


### PR DESCRIPTION
"-" and "-" are very common to be used as a part of CSS class or id.
Request to allow them as Match field.
