### PR TITLE
Default customizable keyboard shortcut

### DIFF
--- a/formfiller/js-chrome/background.js
+++ b/formfiller/js-chrome/background.js
@@ -91,3 +91,9 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
         chrome.tabs.executeScript(null, { code: 'if (window.formFiller) { window.formFiller.fillThisInput(); }', allFrames: true })
     }
 });
+
+//Shortcut listner
+chrome.commands.onCommand.addListener(function(command) {
+    ga('send', 'event', 'extension_button', 'shortcut');
+    chrome.tabs.executeScript(null, { code: 'if (window.formFiller) { window.formFiller.fillAllInputs(); }', allFrames: true })
+});

--- a/formfiller/js-chrome/background.js
+++ b/formfiller/js-chrome/background.js
@@ -18,10 +18,7 @@ function handleUpgrade() {
         currentVersion = chrome.app.getDetails().version;
 
     if (currentVersion != previousVersion) {
-        if (typeof previousVersion == 'undefined') {
-            // New installation
-        } else {
-            // Upgrade
+        if (typeof previousVersion != 'undefined') {// If not new instalation then upgrade
 
             if (previousVersion.substr(0, 1) == '1') {
                 SaveFormFillerOptions(FormFillerDefaultOptions());

--- a/formfiller/manifest.json
+++ b/formfiller/manifest.json
@@ -13,6 +13,14 @@
         "default_icon": "images/icon-48.png",
         "default_title": "Fill all inputs with dummy data"
     },
+    "commands": {
+          "fill_all_inputs": {
+            "suggested_key": {
+              "default": "Alt+Space"
+            },
+            "description": "Fill forms"
+        }
+    },
     "content_scripts": [
         {
             "matches": [ "<all_urls>" ],

--- a/readme.markdown
+++ b/readme.markdown
@@ -4,5 +4,5 @@ This extension allows you to fill all form inputs (textboxes, textareas, radio b
 
 https://chrome.google.com/webstore/detail/bnjjngeaknajbdcgpfkgnonkmififhfo
 
-###### Default shortcut
+##### Default shortcut
 Use ***Alt+Space*** to fire the extension. This can be edited from the Chrome extesnsions -> keyboard shortcuts.

--- a/readme.markdown
+++ b/readme.markdown
@@ -3,3 +3,6 @@
 This extension allows you to fill all form inputs (textboxes, textareas, radio buttons, dropdowns, etc.) with dummy data. It is a must for developers who work with forms as it avoids the need for manually entering values in fields.
 
 https://chrome.google.com/webstore/detail/bnjjngeaknajbdcgpfkgnonkmififhfo
+
+###### Default shortcut
+Use ***Alt+Space*** to fire the extension. This can be edited from the Chrome extesnsions -> keyboard shortcuts.


### PR DESCRIPTION
I've created this PR because even if the user could create a keyboard shortcut, it would be nice if it would come natively.(Alt+Space) 

The user can still customize it from the Chrome extesnsions -> keyboard shortcuts.

I've also did a little refactor in the if condition in background.js..