### PR TITLE
Use .length instead of .size()

### DIFF
--- a/formfiller/js-chrome/content.js
+++ b/formfiller/js-chrome/content.js
@@ -431,7 +431,7 @@ var FormFiller = function ($, options, analyticsTrackingCode) {
                 }
 
                 if (element.type == 'radio') {
-                    if ($('input[name="' + element.name + '"]:checked').size() > 0) {
+                    if ($('input[name="' + element.name + '"]:checked').length > 0) {
                         return true;
                     }
                 }


### PR DESCRIPTION
size is deprecated in 1.8 and removed in 3.0. Reference: https://api.jquery.com/size/