### PR TITLE
check for element.val() to support select with disabled default

### DIFF
--- a/formfiller/js-chrome/content.js
+++ b/formfiller/js-chrome/content.js
@@ -438,7 +438,7 @@ var FormFiller = function ($, options, analyticsTrackingCode) {
                 }
 
                 if (element.type !== 'checkbox' && element.type != 'radio') {
-                    if ($(element).val().trim().length > 0) {
+                    if ($(element).val() && $(element).val().trim().length > 0) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Given I `Ignore fields that already have content`

> <img width="924" alt="screen shot 2016-12-05 at 4 54 11 pm" src="https://cloud.githubusercontent.com/assets/81055/20878743/79970a9a-bb0b-11e6-9151-cd85ceb65232.png">


And I have a form with a `select` field with a default option `selected:disabled`

> <img width="955" alt="screen shot 2016-12-05 at 4 29 35 pm" src="https://cloud.githubusercontent.com/assets/81055/20878657/2c04bd0e-bb0b-11e6-9ba6-4b35318cc032.png">

An exception is caused on `trim()` being called on a null `val()`.

`content.js:441 Uncaught TypeError: Cannot read property 'trim' of null(…)`

> <img width="860" alt="screen shot 2016-12-05 at 4 53 46 pm" src="https://cloud.githubusercontent.com/assets/81055/20878723/6887fbf6-bb0b-11e6-81e8-74c61222a779.png">

This pull request adds a check for `val()` before calling `trim()`