### PR TITLE
Search in all field's labels

### DIFF
--- a/app/scripts.babel/form-filler/data-generator.js
+++ b/app/scripts.babel/form-filler/data-generator.js
@@ -356,9 +356,9 @@ class DataGenerator {
     }
 
     if (this.options.fieldMatchSettings.matchLabel) {
-      const label = jQuery(`label[for='${element.id}']`);
-      if (label.length === 1) {
-        sanitizedElementName += ` ${this.sanitizeName(label.html())}`;
+      const labels = jQuery(`label[for='${element.id}']`);
+      for (let i = 0; i < labels.length; i += 1) {
+        sanitizedElementName += ` ${this.sanitizeName(labels[i].innerHTML)}`;
       }
     }
 


### PR DESCRIPTION
According HTML5 documentation, an input can have multiples labels associated. So this PR permit Form filler to search in all labels associated with an input and not just the first label found.