### PR TITLE
Make text formatting consistent with other plugins

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6,7 +6,7 @@
     "message": "Fill all inputs in a page with dummy data."
   },
   "browserActionTitle": {
-    "message": "Fill all inputs with dummy data."
+    "message": "Fill All Inputs with Dummy Data"
   },
   "commands_FillThisForm": {
     "message": "Fill this form"


### PR DESCRIPTION
This is a minor update to the label (browserActionTitle) to make it consistent with most Firefox plugins. I have removed the period at the end of the label and switched the label to use Title Case (AP Style). This minor text formatting change will allow Form Filler to blend in better with other plugins in the Firefox overflow menu.