### PR TITLE
Add the possibility to set a max words option for generatePhrase function

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -407,6 +407,12 @@
   "generalSettings_contextMenuLabel": {
     "message": "Add items to the right click menu"
   },
+  "generalSettings_maxWords": {
+    "message": "Max Words"
+  },
+  "generalSettings_maxWordsHelp": {
+    "message": "Enter the maximum words by default when filling an input with dummy text"
+  },
   "generalSettings_settingsSaved": {
     "message": "Saved settings."
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -407,6 +407,12 @@
   "generalSettings_contextMenuLabel": {
     "message": "添加到右击菜单中"
   },
+  "generalSettings_maxWords": {
+    "message": "最大词"
+  },
+  "generalSettings_maxWordsHelp": {
+    "message": "在使用虚拟文本填充输入时，默认情况下输入最大单词"
+  },
   "generalSettings_settingsSaved": {
     "message": "保存设置."
   },

--- a/app/scripts.babel/form-filler/data-generator.js
+++ b/app/scripts.babel/form-filler/data-generator.js
@@ -193,8 +193,7 @@ class DataGenerator {
   }
 
   generatePhrase(maxLength) {
-    const length = this.generateNumber(5, 20);
-    const resultPhrase = this.generateWords(length, maxLength);
+    const resultPhrase = this.generateWords(this.options.maxWords, maxLength);
 
     return resultPhrase.replace(/[^\w\s]|_/g, '').replace(/\s+/g, ' ');
   }

--- a/app/scripts.babel/form-filler/helpers.js
+++ b/app/scripts.babel/form-filler/helpers.js
@@ -7,6 +7,7 @@ function FormFillerDefaultOptions() {
   options.ignoredFields = ['captcha', 'hipinputtext'];
   options.confirmFields = ['confirm', 'reenter', 'retype', 'repeat'];
   options.agreeTermsFields = ['agree', 'terms', 'conditions'];
+  options.maxWords = 5;
 
   options.passwordSettings = {
     mode: 'defined',

--- a/app/scripts.babel/options/components/general-settings/GeneralSettingsForm.jsx
+++ b/app/scripts.babel/options/components/general-settings/GeneralSettingsForm.jsx
@@ -210,6 +210,20 @@ class GeneralSettingsForm extends Component {
             />
           </div>
         </div>
+        <div className="form-">
+          <label className="control-label col-sm-3">{GetMessage('generalSettings_maxWords')}</label>
+          <div className="col-sm-9">
+            <Field
+              name="maxWords"
+              type="text"
+              component="input"
+              className="form-control"
+              autoComplete="off"
+              placeholder="5"
+            />
+            <div className="help-block">{GetMessage('generalSettings_maxWordsHelp')}</div>
+          </div>
+        </div>
         <br />
         <div className="form-group">
           <div className="col-sm-offset-3 col-sm-9">


### PR DESCRIPTION
I wanted to resolve #83 by adding a new setting in general settings. You can now set a Max Word value. By default the value is 5.

When filling a text input with dummy content(Lorem ipsum), the string returned will now match the max words value. So now we can avoid getting too much lorem ipsum inside one input text.

<img width="877" alt="screen shot 2018-10-23 at 12 20 04 pm" src="https://user-images.githubusercontent.com/4481970/47375399-2a809400-d6be-11e8-8e1e-822179843f1d.png">
