### PR TITLE
Add email timestamp generator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,9 +53,10 @@ interface ICustomFieldForm {
 interface IEmailSettings {
   hostname: 'list' | 'random';
   hostnameList: string[];
-  username: 'list' | 'name' | 'random' | 'username' | 'regex';
+  username: 'list' | 'name' | 'random' | 'username' | 'regex' | 'timestamp';
   usernameList: string[];
   usernameRegEx: string;
+  usernameTimestamp: string;
 }
 
 interface IFieldMatchSettings {
@@ -90,9 +91,10 @@ interface IFormFillerOptionsForm {
   agreeTermsFields: string;
   confirmFields: string;
   defaultMaxLength: string;
-  emailSettingsUsernameType: 'list' | 'name' | 'random' | 'username' | 'regex';
+  emailSettingsUsernameType: 'list' | 'name' | 'random' | 'username' | 'regex' | 'timestamp';
   emailSettingsUsernameList: string;
   emailSettingsUsernameRegEx: string;
+  emailSettingsUsernameTimestamp: string;
   emailSettingsHostnameType: 'list' | 'random';
   emailSettingsHostnameList: string;
   enableContextMenu: boolean;

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -47,6 +47,9 @@
   "enterCsv": {
     "message": "Enter comma-separated values."
   },
+  "enterName": {
+    "message": "Enter name."
+  },
   "leftNav_General": {
     "message": "General"
   },
@@ -347,11 +350,20 @@
   "generalSettings_label_username_regExTextPlaceholder": {
     "message": "A regular expression."
   },
+  "generalSettings_label_username_timestampLabel": {
+    "message": "Use {{ name }}+{{ current timestamp }}"
+  },
+  "generalSettings_label_username_timestampLabelHelp": {
+    "message": "ex: john+1568987874@example.org"
+  },
   "generalSettings_validation_enterUsernames": {
     "message": "Please enter a list of usernames."
   },
   "generalSettings_validation_enterRegEx": {
     "message": "Please enter a regular expression."
+  },
+  "generalSettings_validation_enterUsernameTimestamp": {
+    "message": "Please enter a name."
   },
   "generalSettings_validation_enterHostname": {
     "message": "Please enter a list of hostnames."

--- a/src/common/data-generator.ts
+++ b/src/common/data-generator.ts
@@ -228,7 +228,11 @@ class DataGenerator {
           // Do nothing.
         }
         break;
-
+        
+      case 'timestamp':
+        username += `${emailSettings.usernameTimestamp}+${new Date().getTime() / 1000 | 0}`;
+        break;
+        
       default:
         break;
     }

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -13,6 +13,7 @@ const FormFillerDefaultOptions = (): IFormFillerOptions => {
       username: 'random',
       usernameList: ['jack', 'sparrow', 'frodo', 'baggins'],
       usernameRegEx: '',
+      usernameTimestamp: 'john',
       hostname: 'list',
       hostnameList: ['mailinator.com', 'mailinator.net'],
     },

--- a/src/options/actions.ts
+++ b/src/options/actions.ts
@@ -100,6 +100,7 @@ export function saveOptions(options: IFormFillerOptions, formValues?: IFormFille
         username: formValues.emailSettingsUsernameType,
         usernameList: CsvToArray(formValues.emailSettingsUsernameList),
         usernameRegEx: formValues.emailSettingsUsernameRegEx,
+        usernameTimestamp: formValues.emailSettingsUsernameTimestamp,
       };
     }
 

--- a/src/options/components/general-settings/GeneralSettingsForm.tsx
+++ b/src/options/components/general-settings/GeneralSettingsForm.tsx
@@ -16,6 +16,10 @@ const validate = (values: IFormFillerOptionsForm): FormikErrors<IFormFillerOptio
   if (values.emailSettingsUsernameType === 'regex' && !values.emailSettingsUsernameRegEx) {
     errors.emailSettingsUsernameRegEx = GetMessage('generalSettings_validation_enterRegEx');
   }
+  
+  if (values.emailSettingsUsernameType === 'timestamp' && !values.emailSettingsUsernameTimestamp) {
+    errors.emailSettingsUsernameTimestamp = GetMessage('generalSettings_validation_enterUsernameTimestamp');
+  }
 
   if (values.emailSettingsHostnameType === 'list' && !values.emailSettingsHostnameList) {
     errors.emailSettingsHostnameList = GetMessage('generalSettings_validation_enterHostname');
@@ -87,6 +91,7 @@ class GeneralSettingsForm extends React.PureComponent<IOwnProps> {
     initialValues.emailSettingsUsernameType = this.props.options.emailSettings.username;
     initialValues.emailSettingsUsernameList = this.props.options.emailSettings.usernameList.join(', ');
     initialValues.emailSettingsUsernameRegEx = this.props.options.emailSettings.usernameRegEx;
+    initialValues.emailSettingsUsernameTimestamp = this.props.options.emailSettings.usernameTimestamp;
 
     return (
       <Formik
@@ -130,6 +135,17 @@ class GeneralSettingsForm extends React.PureComponent<IOwnProps> {
                   label={GetMessage('generalSettings_label_username_regExTextPlaceholder')}
                 />
                 <TextField name="emailSettingsUsernameRegEx" placeholder={GetMessage('enterCsv')} />
+                <RadioButtonField
+                  name="emailSettingsUsernameType"
+                  value="timestamp"
+                  label={GetMessage('generalSettings_label_username_timestampLabel')}
+                />
+                <div className="form-text text-muted">
+                  <span
+                    dangerouslySetInnerHTML={GetHtmlMarkup(GetMessage('generalSettings_label_username_timestampLabelHelp'))}
+                  />
+                </div>
+                <TextField name="emailSettingsUsernameTimestamp" placeholder={GetMessage('enterName')} />
               </div>
             </div>
 


### PR DESCRIPTION
Fix #107 

Allow to generate a alias for some mail provider with the '+' character and a timestamp.
ex: john+1568987874@example.org

![capture d'écran_3](https://user-images.githubusercontent.com/2025537/65335576-f57a0b80-dbc4-11e9-9dce-bb500e71258c.png)

A sample page with all basic stuff:

![capture d'écran_4](https://user-images.githubusercontent.com/2025537/65335583-f7dc6580-dbc4-11e9-98aa-74ba61c6fb99.png)
