### PR TITLE
Form may have value secondary for confirmation

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -7,7 +7,7 @@ const DEFAULT_TELEPHONE_TEMPLATE = '+1 (XxX) XxX-XxxX';
 const FormFillerDefaultOptions = (): IFormFillerOptions => {
   const options: IFormFillerOptions = {
     agreeTermsFields: ['agree', 'terms', 'conditions'],
-    confirmFields: ['confirm', 'reenter', 'retype', 'repeat'],
+    confirmFields: ['confirm', 'reenter', 'retype', 'repeat', 'secondary'],
     defaultMaxLength: 20,
     emailSettings: {
       username: 'random',


### PR DESCRIPTION
Some of the form builders have a `secondary` index for confirmation values. Let's accept this in the form-filler by default as settings were not synced automatically.